### PR TITLE
⬆ Upgrade to Powershell 7.1 and .NET 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       time: "12:00"
     commit-message:
       prefix: 👷
+    labels: [github-actions, dependencies]
   - package-ecosystem: nuget
     directory: /
     schedule:
@@ -16,3 +17,4 @@ updates:
       time: "12:00"
     commit-message:
       prefix: ⬆
+    labels: [.NET, dependencies]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         cfg: [Release, Debug]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: ['3.1.x']
+        version: ['5.x']
     runs-on: ${{ matrix.os }}
     env:
       DOTNET_NOLOGO: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,11 @@ jobs:
       run: dotnet format --check
     - name: Build Project
       run: >-
-        dotnet build --no-restore
+        dotnet build --nologo --no-restore
         --configuration ${{ matrix.cfg }}
     - name: Run Tests
       working-directory: ${{github.workspace}}/Atmosphere.Tests
       run: >-
-        dotnet test --no-restore
+        dotnet test --nologo --no-restore
         --configuration ${{ matrix.cfg }}
         --logger "console;verbosity=normal"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        cfg: [Debug, Release]
+        cfg: [debug, release]
         os: [ubuntu-latest, macos-latest, windows-latest]
         version: ['3.1.x']
     runs-on: ${{ matrix.os }}
@@ -24,4 +24,19 @@ jobs:
       - name: Build Project
         run: dotnet build --configuration ${{ matrix.cfg }}
       - name: Create Package
-        run: dotnet pack --configuration ${{ matrix.cfg }} --version-suffix ${{ github.sha }}
+        run: >-
+          dotnet pack --nologo
+          --no-build
+          --configuration ${{ matrix.cfg }}
+          --version-suffix ${{ github.sha }}
+        id: pack
+      - name: Publish Package
+        if: matrix.cfg == 'release'
+        run: >-
+          dotnet nuget push --nologo
+          --force-english-output
+          --skip-duplicate
+          --api-key ${{secrets.PWSH_TOKEN}}
+          --source https://www.powershellgallery.com
+          --timeout 60
+          ${{steps.pack.outputs.package}}

--- a/Atmosphere.Tests/Atmosphere.Tests.csproj
+++ b/Atmosphere.Tests/Atmosphere.Tests.csproj
@@ -1,18 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsetVersion="16.11.0">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CoverletOutputFormat>opencover</CoverletOutputFormat>
     <CollectCoverage>true</CollectCoverage>
     <UseSourceLink>true</UseSourceLink>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <Exclude>[System.Text.Encodings.Web]*</Exclude>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\xunit.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="codecov.msbuild" Version="1.13.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="codecov.msbuild" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Atmosphere\Atmosphere.csproj" />

--- a/Atmosphere.Tests/xunit.runsettings
+++ b/Atmosphere.Tests/xunit.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TreatNoTestsAsError>true</TreatNoTestsAsError>
+  </RunConfiguration>
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="console" enabled="true">
+        <Configuration>
+          <Verbosity>detailed</Verbosity>
+        </Configuration>
+      </Logger>
+    </Loggers>
+  </LoggerRunSettings>
+</RunSettings>

--- a/Atmosphere/Atmosphere.csproj
+++ b/Atmosphere/Atmosphere.csproj
@@ -1,15 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsetVersion="16.11.0">
+<Project Sdk="Microsoft.NET.Sdk" >
   <!-- Package Metadata -->
   <PropertyGroup>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
-    <Authors>Isabella Muerte</Authors>
-    <Version>0.2.0-alpha</Version>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--PackageReadmeFile>README.md</PackageReadmeFile-->
     <PackageType>PowershellBinaryModule</PackageType>
-    <Description>Environment Variable and Environment Path Manipulation</Description>
-    <RepositoryUrl>https://github.com/slurps-mad-rips/atmosphere</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <!-- Build Properties -->
     <PackageOutputPath>$(SolutionDir)</PackageOutputPath>
     <TargetsForTfmSpecificContentInPackage>PowershellManifest</TargetsForTfmSpecificContentInPackage>
@@ -17,7 +11,6 @@
     <NoWarn>NU5100;NU5128</NoWarn>
     <!-- Custom Properties -->
     <PackageFilename>$(AssemblyName).$(Version).nupkg</PackageFilename>
-    <Pwsh>pwsh -NoProfile -NonInteractive -NoLogo</Pwsh>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(AssemblyName).ps?1" CopyToOutputDirectory="PreserveNewest" />
@@ -30,6 +23,6 @@
     </ItemGroup>
   </Target>
   <Target Name="Inspect" DependsOnTargets="Pack">
-    <GetArchiveEntries Archive="$(PackageOutputPath)\$(PackageFilename)"/>
+    <GetArchiveEntries Archive="$(PackageOutputPath)\$(PackageFilename)" />
   </Target>
 </Project>

--- a/Atmosphere/Atmosphere.psd1
+++ b/Atmosphere/Atmosphere.psd1
@@ -4,9 +4,9 @@
   CompanyName = ''
   Copyright = '(c) Isabella Muerte. All rights reserved.'
   Description = 'Cmdlets for working with environment variables and paths'
-  ModuleVersion = '0.2.0'
+  ModuleVersion = '0.3.0'
   CompatiblePSEditions = 'Core'
-  PowerShellVersion = '7.0'
+  PowerShellVersion = '7.1'
   RootModule = 'Atmosphere.dll'
 
   CmdletsToExport = @(
@@ -36,6 +36,22 @@
       ProjectUri = 'https://github.com/slurps-mad-rips/atmosphere'
       Prerelease = 'Alpha'
       ReleaseNotes = @'
+# 0.3.0-Alpha
+
+⬆ Upgrade to Powershell 7.1 and .NET 5
+
+This was a long time coming, as 7.1 is the closest thing to a stable release
+for some time now. The primary changes with this release are a bump in
+dependencies and a change in how the project is generated. Having the prior
+0.2.0-Alpha allows us to break free from Powershell 7.0 and still have a
+general 'upgrade' path for users.
+
+🔨 Modify build system to be more streamlined/helpful
+
+The build system was streamlined ever so slightly to improve the build
+experience. We still have a bunch of work to go, but the build itself is now
+more helpful in GitHub Actions.
+
 # 0.2.0-Alpha
 
 ♻ Rewrote all cmdlets as Binary Cmdlets.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,17 +1,28 @@
 <Project>
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Description>Environment Variable and Environment Path Manipulation</Description>
+    <RepositoryUrl>https://github.com/slurps-mad-rips/atmosphere</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Authors>Isabella Muerte</Authors>
+    <Version>0.3.0-alpha</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.PowerShell.SDK" PrivateAssets="All" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(CI)' == 'true'">
       <PropertyGroup>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.Github" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.Github" PrivateAssets="All" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -20,7 +31,4 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.7" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,14 @@
 <Project ToolsVersion="16.11.0">
+  <!--Import Project="GitHub.targets" Condition="'$(ContinuousIntegrationBuild)' == 'true'"/-->
+  <Target Name="GroupStart" BeforeTargets="CoreCompile;Pack;VSTest" Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <Message Importance="High" Text="::group::$(MSBuildProjectName)" />
+  </Target>
+  <Target Name="GroupEnd" AfterTargets="Build;Pack;VSTest" Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <Message Importance="High" Text="::endgroup::" />
+  </Target>
+  <Target Name="GithubActions" AfterTargets="Pack" Condition="'$(PackageFilename)' != '' and '$(ContinuousIntegrationBuild)' == 'true'">
+    <Message Importance="High" Text="::set-output name=package::$(PackageOutputPath)$(PackageFilename)" />
+  </Target>
   <UsingTask TaskName="GetArchiveEntries"
              TaskFactory="RoslynCodeTaskFactory"
              AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <MicrosoftBuildPackageVersion>16.11.0</MicrosoftBuildPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.1.4" Pin="true"/>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="codecov.msbuild" Version="1.13.0" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="3.1.0" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This was a long time coming, as 7.1 is the closest thing to a stable release for some time now. The primary changes with this release are a bump in dependencies and a change in how the project is generated. Having the prior 0.2.0-Alpha allows us to break free from Powershell 7.0 and still have a general 'upgrade' path for users. 

🔨 Modify build system to be more streamlined/helpful 

The build system was streamlined ever so slightly to improve the build experience. We still have a bunch of work to go, but the build itself is now more helpful in GitHub Actions.    